### PR TITLE
Update the syntax for the ethernet module

### DIFF
--- a/raumfuhler-serverraum-3og.yaml
+++ b/raumfuhler-serverraum-3og.yaml
@@ -20,7 +20,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    pin: GPIO17
+    mode: CLK_OUT
   phy_addr: 0
   power_pin: GPIO12
 

--- a/raumfuhler-serverraum-3ug.yaml
+++ b/raumfuhler-serverraum-3ug.yaml
@@ -20,7 +20,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    pin: GPIO17
+    mode: CLK_OUT
   phy_addr: 0
   power_pin: GPIO5
 


### PR DESCRIPTION
because the current syntax is being deprecated

```
WARNING [ethernet] The 'clk_mode' option is deprecated and will be removed in ESPHome 2026.1. Please update your configuration to use 'clk' instead.
```