### PR TITLE
this library needs the model key

### DIFF
--- a/raumfuhler-serverraum-3ug.yaml
+++ b/raumfuhler-serverraum-3ug.yaml
@@ -35,6 +35,7 @@ web_server:
 
 bme68x_bsec2_i2c:
   address: 0x77
+  model: bme680
 
 sensor:
   - platform: bme68x_bsec2


### PR DESCRIPTION
see [the docu](https://esphome.io/components/sensor/bme68x_bsec2/#configuration-variables)
 ```
 model (Required, string): The model of the connected sensor; either BME680 or BME688.
 ```